### PR TITLE
Upload unuploaded data before and after each ping

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,5 +11,7 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": "off",
 
     "react/no-did-mount-set-state": "off",
+
+    "no-useless-return": "off",
   },
 };

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -999,33 +999,7 @@ export default class HomeScreen extends React.Component<
             this.setState({ currentPing: finishedPing });
             this._uploadUnuploadedDataAndRemoveFromThemIfSuccessfulAsync(
               async (response) => {
-                let isDataDiscrepant = false;
-
-                const serverPingsCount = response.new_pings_count;
-                if (serverPingsCount != null) {
-                  const localPingsCount = (await getPingsListAsync()).length;
-                  if (serverPingsCount !== localPingsCount) {
-                    console.warn(
-                      `serverPingsCount (${serverPingsCount}) != localPingsCount (${localPingsCount})!`,
-                    );
-                    isDataDiscrepant = true;
-                  }
-                }
-
-                const serverAnswersCount = response.new_answers_count;
-                if (serverAnswersCount != null) {
-                  const localAnswersCount = (
-                    await getAnswersPingIdsQuestionIdsListAsync()
-                  ).length;
-                  if (serverAnswersCount !== localAnswersCount) {
-                    console.warn(
-                      `serverAnswersCount (${serverAnswersCount}) != localAnswersCount (${localAnswersCount})!`,
-                    );
-                    isDataDiscrepant = true;
-                  }
-                }
-
-                if (isDataDiscrepant) {
+                const showDataDiscrepencyAlert = () => {
                   Alert.alert(
                     "Data Discrepancy Detected",
                     "The data on your phone locally does not match the data we have on the server. " +
@@ -1052,6 +1026,32 @@ export default class HomeScreen extends React.Component<
                       },
                     ],
                   );
+                };
+
+                const serverPingsCount = response.new_pings_count;
+                if (serverPingsCount != null) {
+                  const localPingsCount = (await getPingsListAsync()).length;
+                  if (serverPingsCount !== localPingsCount) {
+                    console.warn(
+                      `serverPingsCount (${serverPingsCount}) != localPingsCount (${localPingsCount})!`,
+                    );
+                    showDataDiscrepencyAlert();
+                    return;
+                  }
+                }
+
+                const serverAnswersCount = response.new_answers_count;
+                if (serverAnswersCount != null) {
+                  const localAnswersCount = (
+                    await getAnswersPingIdsQuestionIdsListAsync()
+                  ).length;
+                  if (serverAnswersCount !== localAnswersCount) {
+                    console.warn(
+                      `serverAnswersCount (${serverAnswersCount}) != localAnswersCount (${localAnswersCount})!`,
+                    );
+                    showDataDiscrepencyAlert();
+                    return;
+                  }
                 }
               },
             );

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -339,16 +339,18 @@ export default class HomeScreen extends React.Component<
       unuploadedOnly: true,
       // We do this to avoid the data being modified before being uploaded.
       prefetchedData: prevData,
-    }).then(async (result) => {
-      // We have to use `.then` here because we don't want to block.
-
-      if (result != null) {
+    })
+      .then(async (result) => {
+        // We have to use `.then` here because we don't want to block.
+        const response = await removeFromUnuploadedPingsListAsync(
+          prevUnuploaded,
+        );
+      })
+      .catch((e) => {
         // There's some error in uploading.
-        // Do nothing (keep them in the unuploaded pings list).
-      } else {
-        await removeFromUnuploadedPingsListAsync(prevUnuploaded);
-      }
-    });
+        // Do nothing (keep the unuploaded pings list unmodified).
+        console.warn(`Upload error! ${e}`);
+      });
   }
 
   async _startSurveyTypeAsync(streamName: StreamName) {
@@ -430,15 +432,22 @@ export default class HomeScreen extends React.Component<
                               {
                                 text: "Force upload ALL of my current data!",
                                 onPress: async () => {
-                                  const response = await uploadDataAsync(
-                                    studyInfo,
-                                    this.setUploadStatusSymbol,
-                                    { unuploadedOnly: false },
-                                  );
-                                  alertWithShareButtonContainingDebugInfo(
-                                    `${response}`,
-                                    "Data Upload Response",
-                                  );
+                                  try {
+                                    const response = await uploadDataAsync(
+                                      studyInfo,
+                                      this.setUploadStatusSymbol,
+                                      { unuploadedOnly: false },
+                                    );
+                                    alertWithShareButtonContainingDebugInfo(
+                                      JSON.stringify(response),
+                                      "Data Upload Response",
+                                    );
+                                  } catch (e) {
+                                    alertWithShareButtonContainingDebugInfo(
+                                      getNonCriticalProblemTextForUser(`${e}`),
+                                      "Error: Data Upload Error",
+                                    );
+                                  }
                                 },
                               },
                             ],
@@ -687,24 +696,36 @@ export default class HomeScreen extends React.Component<
             color="orange"
             title="uploadDataAsync(all)"
             onPress={async () => {
-              const response = await uploadDataAsync(
-                studyInfo,
-                this.setUploadStatusSymbol,
-                { unuploadedOnly: false },
-              );
-              alertWithShareButtonContainingDebugInfo(`${response}`);
+              try {
+                const response = await uploadDataAsync(
+                  studyInfo,
+                  this.setUploadStatusSymbol,
+                  { unuploadedOnly: false },
+                );
+                alertWithShareButtonContainingDebugInfo(
+                  JSON.stringify(response),
+                );
+              } catch (e) {
+                alertWithShareButtonContainingDebugInfo(`${e}`);
+              }
             }}
           />
           <Button
             color="orange"
             title="uploadDataAsync(unuploaded)"
             onPress={async () => {
-              const response = await uploadDataAsync(
-                studyInfo,
-                this.setUploadStatusSymbol,
-                { unuploadedOnly: true },
-              );
-              alertWithShareButtonContainingDebugInfo(`${response}`);
+              try {
+                const response = await uploadDataAsync(
+                  studyInfo,
+                  this.setUploadStatusSymbol,
+                  { unuploadedOnly: true },
+                );
+                alertWithShareButtonContainingDebugInfo(
+                  JSON.stringify(response),
+                );
+              } catch (e) {
+                alertWithShareButtonContainingDebugInfo(`${e}`);
+              }
             }}
           />
           <Button
@@ -828,15 +849,17 @@ export default class HomeScreen extends React.Component<
               <Button
                 title="Upload Your Data"
                 onPress={async () => {
-                  const response = await uploadDataAsync(
-                    studyInfo,
-                    this.setUploadStatusSymbol,
-                    { unuploadedOnly: false },
-                  );
-                  if (response === null) {
-                    alertWithShareButtonContainingDebugInfo(`Data uploaded.`);
-                  } else {
-                    alertWithShareButtonContainingDebugInfo(`${response}`);
+                  try {
+                    const response = await uploadDataAsync(
+                      studyInfo,
+                      this.setUploadStatusSymbol,
+                      { unuploadedOnly: false },
+                    );
+                    alertWithShareButtonContainingDebugInfo(
+                      `Data uploaded. Response: ${JSON.stringify(response)}`,
+                    );
+                  } catch (e) {
+                    alertWithShareButtonContainingDebugInfo(`${e}`);
                   }
                 }}
               />

--- a/src/helpers/answers.ts
+++ b/src/helpers/answers.ts
@@ -11,8 +11,14 @@ import {
 } from "./secureStore/answer";
 import { Question, Ping } from "./types";
 
-export async function getAnswersAsync(): Promise<Answer[]> {
-  const answersList = await getAnswersPingIdsQuestionIdsListAsync();
+export async function getAnswersAsync({
+  unuploadedOnly = false,
+}: {
+  unuploadedOnly?: boolean;
+} = {}): Promise<Answer[]> {
+  const answersList = await getAnswersPingIdsQuestionIdsListAsync({
+    unuploadedOnly,
+  });
 
   // https://stackoverflow.com/q/28066429/2603230
   const answers: Answer[] = await Promise.all(

--- a/src/helpers/asyncStorage/answersPingIdsQuestionIdsList.ts
+++ b/src/helpers/asyncStorage/answersPingIdsQuestionIdsList.ts
@@ -4,7 +4,8 @@ import { Answer } from "../answerTypes";
 import { logAndThrowError } from "../debug";
 import { PingId, QuestionId } from "../types";
 import { getASKeyAsync } from "./asyncStorage";
-import { getPingsListAsync } from "./pingsList";
+import { getPingsListAsync, PingsList } from "./pingsList";
+import { getUnuploadedPingsListAsync } from "./unuploadedPingsList";
 
 export type AnswerPingIdQuestionId = [PingId, QuestionId];
 export type AnswersPingIdsQuestionIdsList = AnswerPingIdQuestionId[];
@@ -59,10 +60,17 @@ export async function getAnswersQuestionIdsListForPingAsync(
   }
 }
 
-export async function getAnswersPingIdsQuestionIdsListAsync(): Promise<
-  AnswersPingIdsQuestionIdsList
-> {
-  const pingsList = await getPingsListAsync();
+export async function getAnswersPingIdsQuestionIdsListAsync({
+  unuploadedOnly = false,
+}: {
+  unuploadedOnly?: boolean;
+} = {}): Promise<AnswersPingIdsQuestionIdsList> {
+  let pingsList: PingsList;
+  if (unuploadedOnly) {
+    pingsList = await getUnuploadedPingsListAsync();
+  } else {
+    pingsList = await getPingsListAsync();
+  }
 
   // https://stackoverflow.com/q/28066429/2603230
   const answersQuestionIdsNested: AnswersPingIdsQuestionIdsList[] = await Promise.all(

--- a/src/helpers/asyncStorage/unuploadedPingsList.ts
+++ b/src/helpers/asyncStorage/unuploadedPingsList.ts
@@ -1,0 +1,67 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import { logAndThrowError } from "../debug";
+import { Ping } from "../types";
+import { getASKeyAsync } from "./asyncStorage";
+import { PingsList } from "./pingsList";
+
+const UNUPLOADED_PINGS_LIST = `unuploadedPingsList`;
+
+async function _setUnuploadedPingsListIfNeededAsync(pingsList: PingsList) {
+  await AsyncStorage.setItem(
+    await getASKeyAsync(UNUPLOADED_PINGS_LIST),
+    JSON.stringify(pingsList),
+  );
+}
+
+export async function addToUnuploadedPingsListIfNeededAsync(ping: Ping) {
+  try {
+    const currentUnuploadedPingsList = await getUnuploadedPingsListAsync();
+    if (currentUnuploadedPingsList.includes(ping.id)) {
+      // Do not add it to the list if it is in the list already.
+      return;
+    }
+
+    currentUnuploadedPingsList.push(ping.id);
+    await _setUnuploadedPingsListIfNeededAsync(currentUnuploadedPingsList);
+  } catch (error) {
+    logAndThrowError(error);
+  }
+}
+
+export async function clearUnuploadedPingsListAsync() {
+  try {
+    await AsyncStorage.removeItem(await getASKeyAsync(UNUPLOADED_PINGS_LIST));
+  } catch (error) {
+    logAndThrowError(error);
+  }
+}
+
+export async function removeFromUnuploadedPingsListAsync(
+  toBeRemoved: PingsList,
+) {
+  try {
+    const currentUnuploadedPingsList = await getUnuploadedPingsListAsync();
+    // https://stackoverflow.com/a/1723220/2603230
+    const newUnuploadedPingsList = currentUnuploadedPingsList.filter(
+      (x) => !toBeRemoved.includes(x),
+    );
+    await _setUnuploadedPingsListIfNeededAsync(newUnuploadedPingsList);
+  } catch (error) {
+    logAndThrowError(error);
+  }
+}
+
+export async function getUnuploadedPingsListAsync(): Promise<PingsList> {
+  try {
+    const value = await AsyncStorage.getItem(
+      await getASKeyAsync(UNUPLOADED_PINGS_LIST),
+    );
+    if (value == null) {
+      return [];
+    }
+    return JSON.parse(value);
+  } catch (error) {
+    logAndThrowError(error);
+  }
+}

--- a/src/helpers/beiwe.ts
+++ b/src/helpers/beiwe.ts
@@ -11,7 +11,7 @@ import { Platform } from "react-native";
 import { UploadData } from "./dataUpload";
 import { JS_VERSION_NUMBER } from "./debug";
 import { User, secureGetUserAsync } from "./secureStore/user";
-import { getBeiweServerConfig } from "./server";
+import { DataUploadServerResponse, getBeiweServerConfig } from "./server";
 import { getStudyInfoAsync } from "./studyFile";
 
 /**
@@ -47,17 +47,21 @@ export async function beiweLoginAsync(user: User): Promise<void> {
   }
 }
 
+/**
+ * Returns a `DataUploadServerResponse` if successful.
+ * Throws an error otherwise.
+ */
 export async function beiweUploadDataForUserAsync(
   data: UploadData,
   startUploading: () => void,
   endUploading: (errorMessage?: string) => void,
-): Promise<Error | null> {
+): Promise<DataUploadServerResponse> {
   startUploading();
 
   const user = await secureGetUserAsync();
   if (user === null) {
     endUploading("BW: U=N");
-    return new Error(
+    throw new Error(
       "secureGetUserAsync() === null in beiweUploadDataForUserAsync",
     );
   }
@@ -73,10 +77,10 @@ export async function beiweUploadDataForUserAsync(
     });
     //console.log(`${JSON.stringify(response)}`);
     endUploading();
-    return null;
+    return response as DataUploadServerResponse;
   } catch (e) {
     endUploading(`BW: ${e.message}`);
-    return e;
+    throw e;
   }
 }
 

--- a/src/helpers/firebase.ts
+++ b/src/helpers/firebase.ts
@@ -80,6 +80,7 @@ export async function firebaseLogoutAndDeleteAppAsync(): Promise<void> {
   }
 }
 
+// TODO: support upload unuploaded
 export async function firebaseUploadDataForUserAsync(
   data: UploadData,
   startUploading: () => void,

--- a/src/helpers/server.ts
+++ b/src/helpers/server.ts
@@ -3,6 +3,14 @@ import { StudyInfo, FirebaseServerConfig, BeiweServerConfig } from "./types";
 
 export type ServerType = "firebase" | "beiwe";
 
+// If the server returns `new_pings_count` and/or `new_answers_count`
+// then we could check them locally to see if the data is consistent.
+export type DataUploadServerResponse = {
+  new_pings_count?: number;
+  new_answers_count?: number;
+  saved_to?: string;
+};
+
 /**
  * If Firebase is used as the backend server.
  */


### PR DESCRIPTION
Previously, we always upload full data to the server each time after the user completes a ping (and before #75, also every half a minute). Now, we only upload unuploaded data, and we only upload these data before the user start a ping and after the user completes a ping. This is so that the user will not experience lag when starting or filling out a ping, because instead of having to get all the data (which is slow and blocks the UI), we just have to get the unuploaded data (which should be faster because the unuploaded data should typically be much smaller than the full data) to upload (more on this in #72).

Details:
- We store a list of unuploaded ping IDs in an array in AsyncStorage. (`src/helpers/asyncStorage/unuploadedPingsList.ts`)
- When the user starts a ping, this new ping ID will be added to the unuploaded ping IDs list.
- Before the user starts a ping (i.e., before the new ping ID is added to the unuploaded ping IDs list) and after the user completes a ping, we (`await` to) get all the unuploaded pings and all the answers associated with these unuploaded pings. We then (in the background, i.e., do not `await` to) upload them to the server.
  - If the upload is successful, we remove these now-uploaded ping IDs from the unuploaded ping IDs list.
  - If the upload is not successful, we do not do anything and keep these still-unuploaded ping IDs in the unuploaded ping IDs list.
- Notice that if the upload the successful, the server (currently Beiwe only) will return the total number of pings and the total number of answers it now stores. (`DataUploadServerResponse`)
- In the case where the upload **after the user has completed a ping** is successful, if any of the two counts returned from the server are different from the counts locally, the user will see an alert message prompting them to upload all data to the server (because similar to before, uploading all data will fully overwrite the existing data on the server).

Resolves #72.