### PR TITLE
Add support for storing login date as part of device ID

### DIFF
--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -57,6 +57,7 @@ import {
   HOME_SCREEN_DEBUG_VIEW_SYMBOLS,
 } from "./helpers/debug";
 import { firebaseLoginAsync, firebaseInitialized } from "./helpers/firebase";
+import { getLoginSessionID } from "./helpers/loginSession";
 import {
   setNotificationsAsync,
   setupNotificationsPermissionAsync,
@@ -508,7 +509,14 @@ export default class HomeScreen extends React.Component<
               {studyInfo.contactEmail && (
                 <TouchableOpacity
                   onPress={async () => {
-                    const user = await secureGetUserAsync();
+                    let user = await secureGetUserAsync();
+                    if (user === null) {
+                      user = {
+                        username: "UNKNOWN ERROR CANNOT GET USER",
+                        password: "N/A",
+                        loginDate: -1,
+                      };
+                    }
 
                     const emailSubject = encodeURIComponent(
                       `Questions about Well Ping study ${studyInfo.id}`,
@@ -516,7 +524,8 @@ export default class HomeScreen extends React.Component<
                     const emailBody = encodeURIComponent(
                       `Please enter your question here (please attach a screenshot if applicable):\n\n\n\n\n\n` +
                         `====\n` +
-                        `User ID: ${user!.username}\n` +
+                        `User ID: ${user.username}\n` +
+                        `User Login Session ID: ${getLoginSessionID(user)}\n` +
                         getUsefulDebugInfo(),
                     );
                     const mailtoLink = `mailto:${studyInfo.contactEmail}?subject=${emailSubject}&body=${emailBody}`;

--- a/src/components/DashboardComponent.tsx
+++ b/src/components/DashboardComponent.tsx
@@ -6,6 +6,7 @@ import { WebView } from "react-native-webview";
 
 import { INSTALLATION_ID } from "../helpers/debug";
 import { base64ToBase64URL, getHashedPasswordAsync } from "../helpers/helpers";
+import { getLoginSessionID } from "../helpers/loginSession";
 import {
   getPingsAsync,
   getThisWeekPingsAsync,
@@ -16,6 +17,7 @@ import { StudyInfo } from "../helpers/types";
 
 const TIMEZONE_OFFSET_PLACEHOLDER = "__TIMEZONE_OFFSET__";
 const INSTALLATION_ID_PLACEHOLDER = "__INSTALLATION_ID__";
+const LOGIN_SESSION_ID_PLACEHOLDER = "__LOGIN_SESSION_ID__";
 const USERNAME_PLACEHOLDER = "__USERNAME__";
 const PASSWORD_HASH_PLACEHOLDER = "__PASSWORD_HASH__";
 const FIREBASE_ID_TOKEN_PLACEHOLDER = "__FIREBASE_ID_TOKEN__";
@@ -39,6 +41,17 @@ export async function getDashboardUrlAsync(
     dashboardUrl = dashboardUrl
       .split(INSTALLATION_ID_PLACEHOLDER)
       .join(INSTALLATION_ID);
+  }
+
+  if (dashboardUrl.includes(LOGIN_SESSION_ID_PLACEHOLDER)) {
+    let loginSessionId = "N/A";
+    const user = await secureGetUserAsync();
+    if (user) {
+      loginSessionId = getLoginSessionID(user);
+    }
+    dashboardUrl = dashboardUrl
+      .split(LOGIN_SESSION_ID_PLACEHOLDER)
+      .join(loginSessionId);
   }
 
   if (dashboardUrl.includes(USERNAME_PLACEHOLDER)) {

--- a/src/helpers/beiwe.ts
+++ b/src/helpers/beiwe.ts
@@ -3,13 +3,13 @@
  * `useBeiwe(studyInfo) === true`.
  */
 
-import Constants from "expo-constants";
 import * as Device from "expo-device";
 import { Platform } from "react-native";
 
 import { UploadData } from "./dataUpload";
 import { JS_VERSION_NUMBER } from "./debug";
 import { base64ToBase64URL, getHashedPasswordAsync } from "./helpers";
+import { getLoginSessionID } from "./loginSession";
 import { User, secureGetUserAsync } from "./secureStore/user";
 import { DataUploadServerResponse, getBeiweServerConfig } from "./server";
 import { getStudyInfoAsync } from "./studyFile";
@@ -53,18 +53,11 @@ export async function beiweLoginAsync(user: User): Promise<void> {
  */
 export async function beiweUploadDataForUserAsync(
   data: UploadData,
+  user: User,
   startUploading: () => void,
   endUploading: (errorMessage?: string) => void,
 ): Promise<DataUploadServerResponse> {
   startUploading();
-
-  const user = await secureGetUserAsync();
-  if (user === null) {
-    endUploading("BW: U=N");
-    throw new Error(
-      "secureGetUserAsync() === null in beiweUploadDataForUserAsync",
-    );
-  }
 
   try {
     const endpoint = "/ssnl_upload";
@@ -84,10 +77,6 @@ export async function beiweUploadDataForUserAsync(
   }
 }
 
-export function getBeiweDeviceId(username: string): string {
-  return `${username}-${Constants.installationId}`;
-}
-
 async function getRequestURLAsync(
   endpoint: string,
   request: { [key: string]: any } = {},
@@ -104,7 +93,7 @@ async function getRequestURLAsync(
 
   const passwordHash = await getHashedPasswordAsync(user.password);
   request["password"] = base64ToBase64URL(passwordHash);
-  request["device_id"] = getBeiweDeviceId(user.username);
+  request["device_id"] = getLoginSessionID(user);
   request["username"] = user.username;
   request["patient_id"] = user.username;
 

--- a/src/helpers/dataUpload.ts
+++ b/src/helpers/dataUpload.ts
@@ -115,11 +115,18 @@ export async function uploadDataAsync(
     );
   };
 
+  const user = await secureGetUserAsync();
+  if (user === null) {
+    endUploading("User===Null");
+    throw new Error("secureGetUserAsync() === null in uploadDataAsync");
+  }
+
   let response: DataUploadServerResponse = {};
   if (useServer(studyInfo)) {
     if (useFirebase(studyInfo)) {
       response = await firebaseUploadDataForUserAsync(
         data,
+        user,
         startUploading,
         endUploading,
       );
@@ -127,6 +134,7 @@ export async function uploadDataAsync(
     if (useBeiwe(studyInfo)) {
       response = await beiweUploadDataForUserAsync(
         data,
+        user,
         startUploading,
         endUploading,
       );

--- a/src/helpers/firebase.ts
+++ b/src/helpers/firebase.ts
@@ -6,7 +6,7 @@
 import * as firebase from "firebase/app";
 
 import { UploadData } from "./dataUpload";
-import { INSTALLATION_ID } from "./debug";
+import { getLoginSessionID } from "./loginSession";
 import { User } from "./secureStore/user";
 import { DataUploadServerResponse, getFirebaseServerConfig } from "./server";
 import { StudyInfo } from "./types";
@@ -87,6 +87,7 @@ export async function firebaseLogoutAndDeleteAppAsync(): Promise<void> {
  */
 export async function firebaseUploadDataForUserAsync(
   data: UploadData,
+  localUser: User,
   startUploading: () => void,
   endUploading: (errorMessage?: string) => void,
 ): Promise<DataUploadServerResponse> {
@@ -107,7 +108,8 @@ export async function firebaseUploadDataForUserAsync(
     const dataPlain = JSON.parse(JSON.stringify(data));
     await firebase
       .database()
-      .ref(`users/${user.uid}/${INSTALLATION_ID}`)
+      // TODO: verify getLoginSessionID is working correctly here
+      .ref(`users/${user.uid}/${getLoginSessionID(localUser)}`)
       .set(dataPlain);
     endUploading();
     // TODO: support new_pings_count` and `new_answers_count.

--- a/src/helpers/loginSession.ts
+++ b/src/helpers/loginSession.ts
@@ -1,0 +1,6 @@
+import { INSTALLATION_ID } from "./debug";
+import { User } from "./secureStore/user";
+
+export const getLoginSessionID = (user: User): string => {
+  return `${user.username}-${INSTALLATION_ID}-${user.loginDate}`;
+};

--- a/src/helpers/secureStore/secureStore.ts
+++ b/src/helpers/secureStore/secureStore.ts
@@ -8,5 +8,7 @@ export async function getSSKeyAsync(key: string = ""): Promise<string> {
   // Note: We include `INSTALLATION_ID` so that the data will NOT be accessible
   // across different installations (as SecureStore will be accessible across
   // different installations by default on iOS).
+  // TODO: `INSTALLATION_ID` will be deprecated. So need to find a better way
+  // of doing this (probably use app first launch date?).
   return `WELLPING-${INSTALLATION_ID}-Study_${studyInfo.id}.${key}`;
 }

--- a/src/helpers/secureStore/user.ts
+++ b/src/helpers/secureStore/user.ts
@@ -7,6 +7,14 @@ import { getSSKeyAsync } from "./secureStore";
 export type User = {
   username: string;
   password: string;
+  /**
+   * The date when the user first logged in. This will be used in conjuction
+   * with the installation ID to unique determine a user's login session.
+   *
+   * We store `number` (from `.getTime()`) instead of `Date` because we don't
+   * have to convert it back to `Date` when `secureGetUserAsync()`.
+   */
+  loginDate: number;
 };
 
 const USER_KEY = `user`;

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -182,6 +182,7 @@ export default class LoginScreen extends React.Component<
       user = {
         username: loginInfo.username,
         password: loginInfo.password,
+        loginDate: new Date().getTime(),
       };
       studyFileURL = loginInfo.studyFileURL;
     } catch (e) {


### PR DESCRIPTION
Previously our data are identified on the server by `${username}-${installation ID}`. However, it seems that installation ID could actually persist over re-installation of the app. This means that we risk overwriting the old data when the user re-installs the app. As such, we further store the login date (time) as a part of ID. Specifically, now we are identified by `${username}-${installation ID}-${login date}`.

This also means logout-then-log-back-in would not erase/overwrite the previous data on the server.