### PR TITLE
Use username+date+hour as fixed random seeds for generating random notification times

### DIFF
--- a/local/debug/DEBUG_STUDY.json
+++ b/local/debug/DEBUG_STUDY.json
@@ -7,7 +7,7 @@
     "dashboardURL": "http://ssnl.stanford.edu/test_dashbord?overall_completed_pings=__PINGS_COMPLETED_OVERALL__&overall_completed_this_week=__PINGS_COMPLETED_THIS_WEEK__&overall_completed_today=__PINGS_COMPLETED_TODAY__&id_token=__ID_TOKEN__",
     "server": {},
     "startDate": "2020-03-10T08:00:00.000Z",
-    "endDate": "2020-04-25T08:00:00.000Z",
+    "endDate": "2030-04-25T08:00:00.000Z",
     "weekStartsOn": 1,
     "frequency": {
       "expireAfterMinutes": 120,

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-native-sqlite-storage": "^5.0.0",
     "react-native-webview": "11.6.2",
     "reflect-metadata": "^0.1.13",
+    "seedrandom": "^3.0.5",
     "url": "^0.11.0",
     "zod": "^1.11.4"
   },

--- a/src/__tests__/helpers/__snapshots__/_pings_related.test.ts.snap
+++ b/src/__tests__/helpers/__snapshots__/_pings_related.test.ts.snap
@@ -11,7 +11,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-01T08:11:08.000Z,
+        "date": 2010-05-01T08:51:49.000Z,
       },
     },
   ],
@@ -24,7 +24,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-01T10:11:08.000Z,
+        "date": 2010-05-01T10:45:22.000Z,
       },
     },
   ],
@@ -37,7 +37,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-01T12:11:08.000Z,
+        "date": 2010-05-01T12:25:25.000Z,
       },
     },
   ],
@@ -50,7 +50,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-01T16:11:08.000Z,
+        "date": 2010-05-01T17:15:37.000Z,
       },
     },
   ],
@@ -63,7 +63,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-01T18:11:08.000Z,
+        "date": 2010-05-01T18:31:20.000Z,
       },
     },
   ],
@@ -76,7 +76,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-01T22:11:08.000Z,
+        "date": 2010-05-01T23:25:04.000Z,
       },
     },
   ],
@@ -89,7 +89,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-02T08:11:08.000Z,
+        "date": 2010-05-02T08:43:31.000Z,
       },
     },
   ],
@@ -102,7 +102,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-02T10:11:08.000Z,
+        "date": 2010-05-02T11:11:02.000Z,
       },
     },
   ],
@@ -115,7 +115,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-02T12:11:08.000Z,
+        "date": 2010-05-02T12:21:18.000Z,
       },
     },
   ],
@@ -128,7 +128,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-02T16:11:08.000Z,
+        "date": 2010-05-02T16:49:29.000Z,
       },
     },
   ],
@@ -141,7 +141,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-02T18:11:08.000Z,
+        "date": 2010-05-02T18:52:02.000Z,
       },
     },
   ],
@@ -154,7 +154,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-02T22:11:08.000Z,
+        "date": 2010-05-02T23:05:40.000Z,
       },
     },
   ],
@@ -167,7 +167,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T08:11:08.000Z,
+        "date": 2010-05-03T08:21:22.000Z,
       },
     },
   ],
@@ -180,7 +180,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T10:11:08.000Z,
+        "date": 2010-05-03T11:09:38.000Z,
       },
     },
   ],
@@ -193,7 +193,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T12:11:08.000Z,
+        "date": 2010-05-03T12:51:29.000Z,
       },
     },
   ],
@@ -206,7 +206,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T16:11:08.000Z,
+        "date": 2010-05-03T16:10:38.000Z,
       },
     },
   ],
@@ -219,7 +219,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T18:11:08.000Z,
+        "date": 2010-05-03T19:13:46.000Z,
       },
     },
   ],
@@ -232,7 +232,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T22:11:08.000Z,
+        "date": 2010-05-03T22:14:37.000Z,
       },
     },
   ],
@@ -245,7 +245,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T08:11:08.000Z,
+        "date": 2010-05-04T08:14:54.000Z,
       },
     },
   ],
@@ -258,7 +258,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T10:11:08.000Z,
+        "date": 2010-05-04T10:56:40.000Z,
       },
     },
   ],
@@ -271,7 +271,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T12:11:08.000Z,
+        "date": 2010-05-04T13:02:02.000Z,
       },
     },
   ],
@@ -284,7 +284,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T16:11:08.000Z,
+        "date": 2010-05-04T16:45:03.000Z,
       },
     },
   ],
@@ -297,7 +297,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T18:11:08.000Z,
+        "date": 2010-05-04T18:29:02.000Z,
       },
     },
   ],
@@ -310,7 +310,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T22:11:08.000Z,
+        "date": 2010-05-04T22:41:54.000Z,
       },
     },
   ],
@@ -606,7 +606,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-15T16:11:08.000Z,
+        "date": 2010-05-15T16:47:01.000Z,
       },
     },
   ],
@@ -619,7 +619,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-15T18:11:08.000Z,
+        "date": 2010-05-15T18:55:42.000Z,
       },
     },
   ],
@@ -632,7 +632,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-15T22:11:08.000Z,
+        "date": 2010-05-15T22:46:21.000Z,
       },
     },
   ],
@@ -645,7 +645,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-16T08:11:08.000Z,
+        "date": 2010-05-16T09:01:30.000Z,
       },
     },
   ],
@@ -658,7 +658,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-16T10:11:08.000Z,
+        "date": 2010-05-16T11:05:53.000Z,
       },
     },
   ],
@@ -671,7 +671,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-16T12:11:08.000Z,
+        "date": 2010-05-16T12:18:46.000Z,
       },
     },
   ],
@@ -684,7 +684,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-16T16:11:08.000Z,
+        "date": 2010-05-16T16:42:40.000Z,
       },
     },
   ],
@@ -697,7 +697,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-16T18:11:08.000Z,
+        "date": 2010-05-16T18:22:24.000Z,
       },
     },
   ],
@@ -710,7 +710,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-16T22:11:08.000Z,
+        "date": 2010-05-16T22:23:25.000Z,
       },
     },
   ],
@@ -723,7 +723,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-17T08:11:08.000Z,
+        "date": 2010-05-17T08:55:39.000Z,
       },
     },
   ],
@@ -736,7 +736,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-17T10:11:08.000Z,
+        "date": 2010-05-17T10:15:49.000Z,
       },
     },
   ],
@@ -749,7 +749,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-17T12:11:08.000Z,
+        "date": 2010-05-17T12:27:37.000Z,
       },
     },
   ],
@@ -762,7 +762,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-17T16:11:08.000Z,
+        "date": 2010-05-17T16:05:30.000Z,
       },
     },
   ],
@@ -775,7 +775,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-17T18:11:08.000Z,
+        "date": 2010-05-17T18:34:37.000Z,
       },
     },
   ],
@@ -788,7 +788,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-17T22:11:08.000Z,
+        "date": 2010-05-17T23:23:59.000Z,
       },
     },
   ],
@@ -801,7 +801,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-18T08:11:08.000Z,
+        "date": 2010-05-18T09:20:20.000Z,
       },
     },
   ],
@@ -814,7 +814,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-18T10:11:08.000Z,
+        "date": 2010-05-18T10:18:13.000Z,
       },
     },
   ],
@@ -827,7 +827,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-18T12:11:08.000Z,
+        "date": 2010-05-18T13:03:39.000Z,
       },
     },
   ],
@@ -840,7 +840,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-18T16:11:08.000Z,
+        "date": 2010-05-18T16:15:35.000Z,
       },
     },
   ],
@@ -853,7 +853,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-18T18:11:08.000Z,
+        "date": 2010-05-18T18:29:46.000Z,
       },
     },
   ],
@@ -866,7 +866,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-18T22:11:08.000Z,
+        "date": 2010-05-18T22:27:55.000Z,
       },
     },
   ],
@@ -1149,7 +1149,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-15T16:11:08.000Z,
+        "date": 2010-05-15T16:47:01.000Z,
       },
     },
   ],
@@ -1162,7 +1162,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-15T18:11:08.000Z,
+        "date": 2010-05-15T18:55:42.000Z,
       },
     },
   ],
@@ -1175,7 +1175,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-15T22:11:08.000Z,
+        "date": 2010-05-15T22:46:21.000Z,
       },
     },
   ],
@@ -1188,7 +1188,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-16T08:11:08.000Z,
+        "date": 2010-05-16T09:01:30.000Z,
       },
     },
   ],
@@ -1201,7 +1201,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-16T10:11:08.000Z,
+        "date": 2010-05-16T11:05:53.000Z,
       },
     },
   ],
@@ -1214,7 +1214,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-16T12:11:08.000Z,
+        "date": 2010-05-16T12:18:46.000Z,
       },
     },
   ],
@@ -1227,7 +1227,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-16T16:11:08.000Z,
+        "date": 2010-05-16T16:42:40.000Z,
       },
     },
   ],
@@ -1240,7 +1240,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-16T18:11:08.000Z,
+        "date": 2010-05-16T18:22:24.000Z,
       },
     },
   ],
@@ -1253,7 +1253,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-16T22:11:08.000Z,
+        "date": 2010-05-16T22:23:25.000Z,
       },
     },
   ],
@@ -1266,7 +1266,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-17T08:11:08.000Z,
+        "date": 2010-05-17T08:55:39.000Z,
       },
     },
   ],
@@ -1279,7 +1279,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-17T10:11:08.000Z,
+        "date": 2010-05-17T10:15:49.000Z,
       },
     },
   ],
@@ -1292,7 +1292,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-17T12:11:08.000Z,
+        "date": 2010-05-17T12:27:37.000Z,
       },
     },
   ],
@@ -1305,7 +1305,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-17T16:11:08.000Z,
+        "date": 2010-05-17T16:05:30.000Z,
       },
     },
   ],
@@ -1318,7 +1318,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-17T18:11:08.000Z,
+        "date": 2010-05-17T18:34:37.000Z,
       },
     },
   ],
@@ -1331,7 +1331,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-17T22:11:08.000Z,
+        "date": 2010-05-17T23:23:59.000Z,
       },
     },
   ],
@@ -1344,7 +1344,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-18T08:11:08.000Z,
+        "date": 2010-05-18T09:20:20.000Z,
       },
     },
   ],
@@ -1357,7 +1357,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-18T10:11:08.000Z,
+        "date": 2010-05-18T10:18:13.000Z,
       },
     },
   ],
@@ -1370,7 +1370,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-18T12:11:08.000Z,
+        "date": 2010-05-18T13:03:39.000Z,
       },
     },
   ],
@@ -1383,7 +1383,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-18T16:11:08.000Z,
+        "date": 2010-05-18T16:15:35.000Z,
       },
     },
   ],
@@ -1396,7 +1396,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-18T18:11:08.000Z,
+        "date": 2010-05-18T18:29:46.000Z,
       },
     },
   ],
@@ -1409,7 +1409,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-18T22:11:08.000Z,
+        "date": 2010-05-18T22:27:55.000Z,
       },
     },
   ],
@@ -1692,7 +1692,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-01T12:11:08.000Z,
+        "date": 2010-05-01T12:25:25.000Z,
       },
     },
   ],
@@ -1705,7 +1705,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-01T16:11:08.000Z,
+        "date": 2010-05-01T17:15:37.000Z,
       },
     },
   ],
@@ -1718,7 +1718,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-01T18:11:08.000Z,
+        "date": 2010-05-01T18:31:20.000Z,
       },
     },
   ],
@@ -1731,7 +1731,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-01T22:11:08.000Z,
+        "date": 2010-05-01T23:25:04.000Z,
       },
     },
   ],
@@ -1744,7 +1744,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-02T08:11:08.000Z,
+        "date": 2010-05-02T08:43:31.000Z,
       },
     },
   ],
@@ -1757,7 +1757,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-02T10:11:08.000Z,
+        "date": 2010-05-02T11:11:02.000Z,
       },
     },
   ],
@@ -1770,7 +1770,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-02T12:11:08.000Z,
+        "date": 2010-05-02T12:21:18.000Z,
       },
     },
   ],
@@ -1783,7 +1783,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-02T16:11:08.000Z,
+        "date": 2010-05-02T16:49:29.000Z,
       },
     },
   ],
@@ -1796,7 +1796,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-02T18:11:08.000Z,
+        "date": 2010-05-02T18:52:02.000Z,
       },
     },
   ],
@@ -1809,7 +1809,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-02T22:11:08.000Z,
+        "date": 2010-05-02T23:05:40.000Z,
       },
     },
   ],
@@ -1822,7 +1822,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T08:11:08.000Z,
+        "date": 2010-05-03T08:21:22.000Z,
       },
     },
   ],
@@ -1835,7 +1835,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T10:11:08.000Z,
+        "date": 2010-05-03T11:09:38.000Z,
       },
     },
   ],
@@ -1848,7 +1848,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T12:11:08.000Z,
+        "date": 2010-05-03T12:51:29.000Z,
       },
     },
   ],
@@ -1861,7 +1861,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T16:11:08.000Z,
+        "date": 2010-05-03T16:10:38.000Z,
       },
     },
   ],
@@ -1874,7 +1874,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T18:11:08.000Z,
+        "date": 2010-05-03T19:13:46.000Z,
       },
     },
   ],
@@ -1887,7 +1887,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T22:11:08.000Z,
+        "date": 2010-05-03T22:14:37.000Z,
       },
     },
   ],
@@ -1900,7 +1900,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T08:11:08.000Z,
+        "date": 2010-05-04T08:14:54.000Z,
       },
     },
   ],
@@ -1913,7 +1913,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T10:11:08.000Z,
+        "date": 2010-05-04T10:56:40.000Z,
       },
     },
   ],
@@ -1926,7 +1926,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T12:11:08.000Z,
+        "date": 2010-05-04T13:02:02.000Z,
       },
     },
   ],
@@ -1939,7 +1939,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T16:11:08.000Z,
+        "date": 2010-05-04T16:45:03.000Z,
       },
     },
   ],
@@ -1952,7 +1952,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T18:11:08.000Z,
+        "date": 2010-05-04T18:29:02.000Z,
       },
     },
   ],
@@ -1965,7 +1965,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T22:11:08.000Z,
+        "date": 2010-05-04T22:41:54.000Z,
       },
     },
   ],
@@ -1983,7 +1983,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T10:11:08.000Z,
+        "date": 2010-05-03T11:09:38.000Z,
       },
     },
   ],
@@ -1996,7 +1996,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T12:11:08.000Z,
+        "date": 2010-05-03T12:51:29.000Z,
       },
     },
   ],
@@ -2009,7 +2009,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T16:11:08.000Z,
+        "date": 2010-05-03T16:10:38.000Z,
       },
     },
   ],
@@ -2022,7 +2022,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T18:11:08.000Z,
+        "date": 2010-05-03T19:13:46.000Z,
       },
     },
   ],
@@ -2035,7 +2035,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-03T22:11:08.000Z,
+        "date": 2010-05-03T22:14:37.000Z,
       },
     },
   ],
@@ -2048,7 +2048,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T08:11:08.000Z,
+        "date": 2010-05-04T08:14:54.000Z,
       },
     },
   ],
@@ -2061,7 +2061,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T10:11:08.000Z,
+        "date": 2010-05-04T10:56:40.000Z,
       },
     },
   ],
@@ -2074,7 +2074,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T12:11:08.000Z,
+        "date": 2010-05-04T13:02:02.000Z,
       },
     },
   ],
@@ -2087,7 +2087,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T16:11:08.000Z,
+        "date": 2010-05-04T16:45:03.000Z,
       },
     },
   ],
@@ -2100,7 +2100,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T18:11:08.000Z,
+        "date": 2010-05-04T18:29:02.000Z,
       },
     },
   ],
@@ -2113,7 +2113,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-04T22:11:08.000Z,
+        "date": 2010-05-04T22:41:54.000Z,
       },
     },
   ],
@@ -2126,7 +2126,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-05T08:11:08.000Z,
+        "date": 2010-05-05T08:55:18.000Z,
       },
     },
   ],
@@ -2139,7 +2139,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-05T10:11:08.000Z,
+        "date": 2010-05-05T10:36:58.000Z,
       },
     },
   ],
@@ -2152,7 +2152,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-05T12:11:08.000Z,
+        "date": 2010-05-05T12:33:53.000Z,
       },
     },
   ],
@@ -2165,7 +2165,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-05T16:11:08.000Z,
+        "date": 2010-05-05T16:32:32.000Z,
       },
     },
   ],
@@ -2178,7 +2178,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-05T18:11:08.000Z,
+        "date": 2010-05-05T18:21:32.000Z,
       },
     },
   ],
@@ -2191,7 +2191,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-05T22:11:08.000Z,
+        "date": 2010-05-05T22:57:55.000Z,
       },
     },
   ],
@@ -2204,7 +2204,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-06T08:11:08.000Z,
+        "date": 2010-05-06T08:56:22.000Z,
       },
     },
   ],
@@ -2217,7 +2217,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-06T10:11:08.000Z,
+        "date": 2010-05-06T10:39:22.000Z,
       },
     },
   ],
@@ -2230,7 +2230,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-06T12:11:08.000Z,
+        "date": 2010-05-06T12:19:39.000Z,
       },
     },
   ],
@@ -2243,7 +2243,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-06T16:11:08.000Z,
+        "date": 2010-05-06T17:23:46.000Z,
       },
     },
   ],
@@ -2256,7 +2256,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-06T18:11:08.000Z,
+        "date": 2010-05-06T18:01:06.000Z,
       },
     },
   ],
@@ -2269,7 +2269,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-06T22:11:08.000Z,
+        "date": 2010-05-06T23:09:30.000Z,
       },
     },
   ],
@@ -2287,7 +2287,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-28T22:11:08.000Z,
+        "date": 2010-05-28T23:19:14.000Z,
       },
     },
   ],
@@ -2300,7 +2300,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-29T08:11:08.000Z,
+        "date": 2010-05-29T09:02:18.000Z,
       },
     },
   ],
@@ -2313,7 +2313,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-29T10:11:08.000Z,
+        "date": 2010-05-29T11:09:55.000Z,
       },
     },
   ],
@@ -2326,7 +2326,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-29T12:11:08.000Z,
+        "date": 2010-05-29T12:48:58.000Z,
       },
     },
   ],
@@ -2339,7 +2339,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-29T16:11:08.000Z,
+        "date": 2010-05-29T17:07:12.000Z,
       },
     },
   ],
@@ -2352,7 +2352,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-29T18:11:08.000Z,
+        "date": 2010-05-29T18:59:44.000Z,
       },
     },
   ],
@@ -2365,7 +2365,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-29T22:11:08.000Z,
+        "date": 2010-05-29T22:10:30.000Z,
       },
     },
   ],
@@ -2378,7 +2378,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-30T08:11:08.000Z,
+        "date": 2010-05-30T09:17:24.000Z,
       },
     },
   ],
@@ -2391,7 +2391,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-30T10:11:08.000Z,
+        "date": 2010-05-30T11:16:35.000Z,
       },
     },
   ],
@@ -2404,7 +2404,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-30T12:11:08.000Z,
+        "date": 2010-05-30T12:01:50.000Z,
       },
     },
   ],
@@ -2417,7 +2417,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-30T16:11:08.000Z,
+        "date": 2010-05-30T17:06:48.000Z,
       },
     },
   ],
@@ -2430,7 +2430,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-30T18:11:08.000Z,
+        "date": 2010-05-30T19:08:26.000Z,
       },
     },
   ],
@@ -2526,7 +2526,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T08:11:08.000Z,
+        "date": 2010-05-12T08:39:16.000Z,
       },
     },
   ],
@@ -2539,7 +2539,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T10:11:08.000Z,
+        "date": 2010-05-12T10:44:49.000Z,
       },
     },
   ],
@@ -2552,7 +2552,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T12:11:08.000Z,
+        "date": 2010-05-12T12:15:43.000Z,
       },
     },
   ],
@@ -2565,7 +2565,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T16:11:08.000Z,
+        "date": 2010-05-12T16:56:26.000Z,
       },
     },
   ],
@@ -2578,7 +2578,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T18:11:08.000Z,
+        "date": 2010-05-12T18:07:56.000Z,
       },
     },
   ],
@@ -2591,7 +2591,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T22:11:08.000Z,
+        "date": 2010-05-12T22:53:33.000Z,
       },
     },
   ],
@@ -2604,7 +2604,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T08:11:08.000Z,
+        "date": 2010-05-13T08:39:23.000Z,
       },
     },
   ],
@@ -2617,7 +2617,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T10:11:08.000Z,
+        "date": 2010-05-13T10:24:09.000Z,
       },
     },
   ],
@@ -2630,7 +2630,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T12:11:08.000Z,
+        "date": 2010-05-13T12:45:33.000Z,
       },
     },
   ],
@@ -2643,7 +2643,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T16:11:08.000Z,
+        "date": 2010-05-13T16:22:20.000Z,
       },
     },
   ],
@@ -2656,7 +2656,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T18:11:08.000Z,
+        "date": 2010-05-13T18:18:44.000Z,
       },
     },
   ],
@@ -2669,7 +2669,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T22:11:08.000Z,
+        "date": 2010-05-13T22:21:26.000Z,
       },
     },
   ],
@@ -2682,7 +2682,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T08:11:08.000Z,
+        "date": 2010-05-14T08:30:54.000Z,
       },
     },
   ],
@@ -2695,7 +2695,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T10:11:08.000Z,
+        "date": 2010-05-14T10:07:45.000Z,
       },
     },
   ],
@@ -2708,7 +2708,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T12:11:08.000Z,
+        "date": 2010-05-14T13:07:27.000Z,
       },
     },
   ],
@@ -2721,7 +2721,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T16:11:08.000Z,
+        "date": 2010-05-14T17:10:35.000Z,
       },
     },
   ],
@@ -2734,7 +2734,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T18:11:08.000Z,
+        "date": 2010-05-14T18:05:08.000Z,
       },
     },
   ],
@@ -2747,7 +2747,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T22:11:08.000Z,
+        "date": 2010-05-14T22:19:19.000Z,
       },
     },
   ],
@@ -2804,7 +2804,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T08:11:08.000Z,
+        "date": 2010-05-12T08:39:16.000Z,
       },
     },
   ],
@@ -2817,7 +2817,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T10:11:08.000Z,
+        "date": 2010-05-12T10:44:49.000Z,
       },
     },
   ],
@@ -2830,7 +2830,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T12:11:08.000Z,
+        "date": 2010-05-12T12:15:43.000Z,
       },
     },
   ],
@@ -2843,7 +2843,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T16:11:08.000Z,
+        "date": 2010-05-12T16:56:26.000Z,
       },
     },
   ],
@@ -2856,7 +2856,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T18:11:08.000Z,
+        "date": 2010-05-12T18:07:56.000Z,
       },
     },
   ],
@@ -2869,7 +2869,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T22:11:08.000Z,
+        "date": 2010-05-12T22:53:33.000Z,
       },
     },
   ],
@@ -2882,7 +2882,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T08:11:08.000Z,
+        "date": 2010-05-13T08:39:23.000Z,
       },
     },
   ],
@@ -2895,7 +2895,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T10:11:08.000Z,
+        "date": 2010-05-13T10:24:09.000Z,
       },
     },
   ],
@@ -2908,7 +2908,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T12:11:08.000Z,
+        "date": 2010-05-13T12:45:33.000Z,
       },
     },
   ],
@@ -2921,7 +2921,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T16:11:08.000Z,
+        "date": 2010-05-13T16:22:20.000Z,
       },
     },
   ],
@@ -2934,7 +2934,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T18:11:08.000Z,
+        "date": 2010-05-13T18:18:44.000Z,
       },
     },
   ],
@@ -2947,7 +2947,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T22:11:08.000Z,
+        "date": 2010-05-13T22:21:26.000Z,
       },
     },
   ],
@@ -2960,7 +2960,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T08:11:08.000Z,
+        "date": 2010-05-14T08:30:54.000Z,
       },
     },
   ],
@@ -2973,7 +2973,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T10:11:08.000Z,
+        "date": 2010-05-14T10:07:45.000Z,
       },
     },
   ],
@@ -2986,7 +2986,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T12:11:08.000Z,
+        "date": 2010-05-14T13:07:27.000Z,
       },
     },
   ],
@@ -2999,7 +2999,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T16:11:08.000Z,
+        "date": 2010-05-14T17:10:35.000Z,
       },
     },
   ],
@@ -3012,7 +3012,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T18:11:08.000Z,
+        "date": 2010-05-14T18:05:08.000Z,
       },
     },
   ],
@@ -3025,7 +3025,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T22:11:08.000Z,
+        "date": 2010-05-14T22:19:19.000Z,
       },
     },
   ],

--- a/src/__tests__/helpers/__snapshots__/_pings_related.test.ts.snap
+++ b/src/__tests__/helpers/__snapshots__/_pings_related.test.ts.snap
@@ -328,7 +328,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-11T16:11:08.000Z,
+        "date": 2010-05-11T17:19:24.000Z,
       },
     },
   ],
@@ -341,7 +341,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-11T18:11:08.000Z,
+        "date": 2010-05-11T19:01:46.000Z,
       },
     },
   ],
@@ -354,7 +354,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-11T22:11:08.000Z,
+        "date": 2010-05-11T22:49:13.000Z,
       },
     },
   ],
@@ -367,7 +367,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T08:11:08.000Z,
+        "date": 2010-05-12T08:39:16.000Z,
       },
     },
   ],
@@ -380,7 +380,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T10:11:08.000Z,
+        "date": 2010-05-12T10:44:49.000Z,
       },
     },
   ],
@@ -393,7 +393,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T12:11:08.000Z,
+        "date": 2010-05-12T12:15:43.000Z,
       },
     },
   ],
@@ -406,7 +406,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T16:11:08.000Z,
+        "date": 2010-05-12T16:56:26.000Z,
       },
     },
   ],
@@ -419,7 +419,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T18:11:08.000Z,
+        "date": 2010-05-12T18:07:56.000Z,
       },
     },
   ],
@@ -432,7 +432,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T22:11:08.000Z,
+        "date": 2010-05-12T22:53:33.000Z,
       },
     },
   ],
@@ -445,7 +445,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T08:11:08.000Z,
+        "date": 2010-05-13T08:39:23.000Z,
       },
     },
   ],
@@ -458,7 +458,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T10:11:08.000Z,
+        "date": 2010-05-13T10:24:09.000Z,
       },
     },
   ],
@@ -471,7 +471,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T12:11:08.000Z,
+        "date": 2010-05-13T12:45:33.000Z,
       },
     },
   ],
@@ -484,7 +484,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T16:11:08.000Z,
+        "date": 2010-05-13T16:22:20.000Z,
       },
     },
   ],
@@ -497,7 +497,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T18:11:08.000Z,
+        "date": 2010-05-13T18:18:44.000Z,
       },
     },
   ],
@@ -510,7 +510,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T22:11:08.000Z,
+        "date": 2010-05-13T22:21:26.000Z,
       },
     },
   ],
@@ -523,7 +523,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T08:11:08.000Z,
+        "date": 2010-05-14T08:30:54.000Z,
       },
     },
   ],
@@ -536,7 +536,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T10:11:08.000Z,
+        "date": 2010-05-14T10:07:45.000Z,
       },
     },
   ],
@@ -549,7 +549,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T12:11:08.000Z,
+        "date": 2010-05-14T13:07:27.000Z,
       },
     },
   ],
@@ -562,7 +562,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T16:11:08.000Z,
+        "date": 2010-05-14T17:10:35.000Z,
       },
     },
   ],
@@ -575,7 +575,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T18:11:08.000Z,
+        "date": 2010-05-14T18:05:08.000Z,
       },
     },
   ],
@@ -588,7 +588,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T22:11:08.000Z,
+        "date": 2010-05-14T22:19:19.000Z,
       },
     },
   ],
@@ -884,7 +884,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-11T18:11:08.000Z,
+        "date": 2010-05-11T19:01:46.000Z,
       },
     },
   ],
@@ -897,7 +897,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-11T22:11:08.000Z,
+        "date": 2010-05-11T22:49:13.000Z,
       },
     },
   ],
@@ -910,7 +910,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T08:11:08.000Z,
+        "date": 2010-05-12T08:39:16.000Z,
       },
     },
   ],
@@ -923,7 +923,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T10:11:08.000Z,
+        "date": 2010-05-12T10:44:49.000Z,
       },
     },
   ],
@@ -936,7 +936,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T12:11:08.000Z,
+        "date": 2010-05-12T12:15:43.000Z,
       },
     },
   ],
@@ -949,7 +949,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T16:11:08.000Z,
+        "date": 2010-05-12T16:56:26.000Z,
       },
     },
   ],
@@ -962,7 +962,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T18:11:08.000Z,
+        "date": 2010-05-12T18:07:56.000Z,
       },
     },
   ],
@@ -975,7 +975,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T22:11:08.000Z,
+        "date": 2010-05-12T22:53:33.000Z,
       },
     },
   ],
@@ -988,7 +988,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T08:11:08.000Z,
+        "date": 2010-05-13T08:39:23.000Z,
       },
     },
   ],
@@ -1001,7 +1001,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T10:11:08.000Z,
+        "date": 2010-05-13T10:24:09.000Z,
       },
     },
   ],
@@ -1014,7 +1014,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T12:11:08.000Z,
+        "date": 2010-05-13T12:45:33.000Z,
       },
     },
   ],
@@ -1027,7 +1027,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T16:11:08.000Z,
+        "date": 2010-05-13T16:22:20.000Z,
       },
     },
   ],
@@ -1040,7 +1040,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T18:11:08.000Z,
+        "date": 2010-05-13T18:18:44.000Z,
       },
     },
   ],
@@ -1053,7 +1053,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T22:11:08.000Z,
+        "date": 2010-05-13T22:21:26.000Z,
       },
     },
   ],
@@ -1066,7 +1066,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T08:11:08.000Z,
+        "date": 2010-05-14T08:30:54.000Z,
       },
     },
   ],
@@ -1079,7 +1079,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T10:11:08.000Z,
+        "date": 2010-05-14T10:07:45.000Z,
       },
     },
   ],
@@ -1092,7 +1092,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T12:11:08.000Z,
+        "date": 2010-05-14T13:07:27.000Z,
       },
     },
   ],
@@ -1105,7 +1105,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T16:11:08.000Z,
+        "date": 2010-05-14T17:10:35.000Z,
       },
     },
   ],
@@ -1118,7 +1118,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T18:11:08.000Z,
+        "date": 2010-05-14T18:05:08.000Z,
       },
     },
   ],
@@ -1131,7 +1131,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T22:11:08.000Z,
+        "date": 2010-05-14T22:19:19.000Z,
       },
     },
   ],
@@ -1427,7 +1427,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-11T18:11:08.000Z,
+        "date": 2010-05-11T19:01:46.000Z,
       },
     },
   ],
@@ -1440,7 +1440,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-11T22:11:08.000Z,
+        "date": 2010-05-11T22:49:13.000Z,
       },
     },
   ],
@@ -1453,7 +1453,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T08:11:08.000Z,
+        "date": 2010-05-12T08:39:16.000Z,
       },
     },
   ],
@@ -1466,7 +1466,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T10:11:08.000Z,
+        "date": 2010-05-12T10:44:49.000Z,
       },
     },
   ],
@@ -1479,7 +1479,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T12:11:08.000Z,
+        "date": 2010-05-12T12:15:43.000Z,
       },
     },
   ],
@@ -1492,7 +1492,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T16:11:08.000Z,
+        "date": 2010-05-12T16:56:26.000Z,
       },
     },
   ],
@@ -1505,7 +1505,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T18:11:08.000Z,
+        "date": 2010-05-12T18:07:56.000Z,
       },
     },
   ],
@@ -1518,7 +1518,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-12T22:11:08.000Z,
+        "date": 2010-05-12T22:53:33.000Z,
       },
     },
   ],
@@ -1531,7 +1531,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T08:11:08.000Z,
+        "date": 2010-05-13T08:39:23.000Z,
       },
     },
   ],
@@ -1544,7 +1544,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T10:11:08.000Z,
+        "date": 2010-05-13T10:24:09.000Z,
       },
     },
   ],
@@ -1557,7 +1557,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T12:11:08.000Z,
+        "date": 2010-05-13T12:45:33.000Z,
       },
     },
   ],
@@ -1570,7 +1570,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T16:11:08.000Z,
+        "date": 2010-05-13T16:22:20.000Z,
       },
     },
   ],
@@ -1583,7 +1583,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T18:11:08.000Z,
+        "date": 2010-05-13T18:18:44.000Z,
       },
     },
   ],
@@ -1596,7 +1596,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-13T22:11:08.000Z,
+        "date": 2010-05-13T22:21:26.000Z,
       },
     },
   ],
@@ -1609,7 +1609,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T08:11:08.000Z,
+        "date": 2010-05-14T08:30:54.000Z,
       },
     },
   ],
@@ -1622,7 +1622,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T10:11:08.000Z,
+        "date": 2010-05-14T10:07:45.000Z,
       },
     },
   ],
@@ -1635,7 +1635,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T12:11:08.000Z,
+        "date": 2010-05-14T13:07:27.000Z,
       },
     },
   ],
@@ -1648,7 +1648,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T16:11:08.000Z,
+        "date": 2010-05-14T17:10:35.000Z,
       },
     },
   ],
@@ -1661,7 +1661,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T18:11:08.000Z,
+        "date": 2010-05-14T18:05:08.000Z,
       },
     },
   ],
@@ -1674,7 +1674,7 @@ Array [
       },
       "trigger": Object {
         "channelId": "ssnlPingChannel",
-        "date": 2010-05-14T22:11:08.000Z,
+        "date": 2010-05-14T22:19:19.000Z,
       },
     },
   ],

--- a/src/__tests__/helpers/notifications.parttest.ts
+++ b/src/__tests__/helpers/notifications.parttest.ts
@@ -24,9 +24,12 @@ export const notificationsTest = () => {
   let mathRandomSpy: FunctionSpyInstance<typeof global.Math.random>;
 
   beforeEach(() => {
+    /*
+    // TODO: we no longer use Math.random (https://github.com/wellping/wellping/pull/92). Instead, we should mock `seedrandom`.
     mathRandomSpy = jest
       .spyOn(global.Math, "random")
       .mockReturnValue(0.123456789);
+    */
 
     mockCurrentStudyInfo(PINGS_STUDY_INFO);
   });

--- a/src/__tests__/helpers/notifications.parttest.ts
+++ b/src/__tests__/helpers/notifications.parttest.ts
@@ -187,7 +187,7 @@ export const notificationsTest = () => {
       });
 
       test("(1 ping from reaching bonus)", async () => {
-        DateMock.advanceTo(+new Date("2010-05-11T13:01:00Z"));
+        DateMock.advanceTo(+new Date("2010-05-11T13:29:30Z"));
 
         await setNotificationsAsync();
 
@@ -201,7 +201,7 @@ export const notificationsTest = () => {
 
       describe("(reached bonus)", () => {
         test("(stay in current week)", async () => {
-          DateMock.advanceTo(+new Date("2010-05-11T17:01:00Z"));
+          DateMock.advanceTo(+new Date("2010-05-11T17:29:30Z"));
 
           await setNotificationsAsync();
 
@@ -241,7 +241,7 @@ export const notificationsTest = () => {
         });
 
         test("(stay in current week)", async () => {
-          DateMock.advanceTo(+new Date("2010-05-11T17:01:00Z"));
+          DateMock.advanceTo(+new Date("2010-05-11T17:29:30Z"));
 
           await setNotificationsAsync();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9099,6 +9099,11 @@ scheduler@^0.17.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+seedrandom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
+
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"


### PR DESCRIPTION
Resolves https://github.com/wellping/wellping/issues/87.

Uses `usernameyyyy-MM-ddhour` as the seed for generating the random time (i.e., minutes and seconds additions) for the notification starting at the `hour` hour on the date `yyyy-MM-dd` for the user `username`.