### PR TITLE
Replace deprecated `Constants.installationId`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-native": "0.64.3",
     "react-native-safe-area-context": "3.3.2",
     "react-native-sqlite-storage": "^5.0.0",
+    "react-native-uuid": "^2.0.1",
     "react-native-webview": "11.13.0",
     "reflect-metadata": "^0.1.13",
     "seedrandom": "^3.0.5",

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -57,7 +57,7 @@ import {
   HOME_SCREEN_DEBUG_VIEW_SYMBOLS,
 } from "./helpers/debug";
 import { firebaseLoginAsync, firebaseInitialized } from "./helpers/firebase";
-import { getLoginSessionID } from "./helpers/loginSession";
+import { getLoginSessionIDAsync } from "./helpers/loginSession";
 import {
   setNotificationsAsync,
   setupNotificationsPermissionAsync,
@@ -636,7 +636,9 @@ export default class HomeScreen extends React.Component<
                       `Please enter your question here (please attach a screenshot if applicable):\n\n\n\n\n\n` +
                         `====\n` +
                         `User ID: ${user.username}\n` +
-                        `User Login Session ID: ${getLoginSessionID(user)}\n` +
+                        `User Login Session ID: ${await getLoginSessionIDAsync(
+                          user,
+                        )}\n` +
                         getUsefulDebugInfo(),
                     );
                     const mailtoLink = `mailto:${studyInfo.contactEmail}?subject=${emailSubject}&body=${emailBody}`;

--- a/src/HomeScreen.tsx
+++ b/src/HomeScreen.tsx
@@ -52,8 +52,8 @@ import {
 import {
   getNonCriticalProblemTextForUser,
   JS_VERSION_NUMBER,
-  getUsefulDebugInfo,
-  alertWithShareButtonContainingDebugInfo,
+  getUsefulDebugInfoAsync,
+  alertWithShareButtonContainingDebugInfoAsync,
   HOME_SCREEN_DEBUG_VIEW_SYMBOLS,
 } from "./helpers/debug";
 import { firebaseLoginAsync, firebaseInitialized } from "./helpers/firebase";
@@ -238,7 +238,7 @@ export default class HomeScreen extends React.Component<
             // We will try to log in the user again first.
             const localStoredUser = await secureGetUserAsync();
             if (localStoredUser === null) {
-              alertWithShareButtonContainingDebugInfo(
+              await alertWithShareButtonContainingDebugInfoAsync(
                 "Not logged in locally!",
                 "Error",
               );
@@ -250,7 +250,7 @@ export default class HomeScreen extends React.Component<
               // If the login is successful, this `onAuthStateChanged` callback
               // will be called again, so we don't have to do anything here.
             } catch (e) {
-              alertWithShareButtonContainingDebugInfo(
+              await alertWithShareButtonContainingDebugInfoAsync(
                 // I'm pretty sure Internet has nothing to do with this, but
                 // we will still tell user to connect to the Internet just in
                 // case.
@@ -263,9 +263,9 @@ export default class HomeScreen extends React.Component<
             }
           }
         },
-        (e) => {
+        async (e) => {
           // Unsure when will this be called.
-          alertWithShareButtonContainingDebugInfo(
+          await alertWithShareButtonContainingDebugInfoAsync(
             `onAuthStateChanged error: ${e}`,
           );
         },
@@ -304,7 +304,7 @@ export default class HomeScreen extends React.Component<
 
     let newStreamName: StreamName;
     if (todayPings.length >= studyInfo.frequency.hoursEveryday.length) {
-      alertWithShareButtonContainingDebugInfo(
+      await alertWithShareButtonContainingDebugInfoAsync(
         getNonCriticalProblemTextForUser(
           `todayPings.length (${todayPings.length}) >= ${studyInfo.frequency.hoursEveryday.length}`,
         ),
@@ -423,12 +423,15 @@ export default class HomeScreen extends React.Component<
         this.setUploadStatusSymbol,
         { unuploadedOnly: false },
       );
-      alertWithShareButtonContainingDebugInfo(
+      await alertWithShareButtonContainingDebugInfoAsync(
         getSuccessMessage(response),
         successTitle,
       );
     } catch (e) {
-      alertWithShareButtonContainingDebugInfo(getErrorMessage(e), errorTitle);
+      await alertWithShareButtonContainingDebugInfoAsync(
+        getErrorMessage(e),
+        errorTitle,
+      );
     }
   }
 
@@ -493,7 +496,7 @@ export default class HomeScreen extends React.Component<
                                         text: "All Data",
                                         onPress: async () => {
                                           const allData = await getAllDataAsync();
-                                          alertWithShareButtonContainingDebugInfo(
+                                          await alertWithShareButtonContainingDebugInfoAsync(
                                             JSON.stringify(allData),
                                             "All Data",
                                             [
@@ -519,7 +522,7 @@ export default class HomeScreen extends React.Component<
                                         text: "Unuploaded Data",
                                         onPress: async () => {
                                           const unuploadedData = await getUnuploadedDataAsync();
-                                          alertWithShareButtonContainingDebugInfo(
+                                          await alertWithShareButtonContainingDebugInfoAsync(
                                             JSON.stringify(unuploadedData),
                                             "Unuploaded Data",
                                             [
@@ -531,7 +534,7 @@ export default class HomeScreen extends React.Component<
                                                       doAfterResponseAsync: async (
                                                         response,
                                                       ) => {
-                                                        alertWithShareButtonContainingDebugInfo(
+                                                        await alertWithShareButtonContainingDebugInfoAsync(
                                                           `Response: ${JSON.stringify(
                                                             response,
                                                           )}`,
@@ -541,7 +544,7 @@ export default class HomeScreen extends React.Component<
                                                       doAfterErrorAsync: async (
                                                         error,
                                                       ) => {
-                                                        alertWithShareButtonContainingDebugInfo(
+                                                        await alertWithShareButtonContainingDebugInfoAsync(
                                                           getNonCriticalProblemTextForUser(
                                                             `Error: ${error}`,
                                                           ),
@@ -639,7 +642,7 @@ export default class HomeScreen extends React.Component<
                         `User Login Session ID: ${await getLoginSessionIDAsync(
                           user,
                         )}\n` +
-                        getUsefulDebugInfo(),
+                        (await getUsefulDebugInfoAsync()),
                     );
                     const mailtoLink = `mailto:${studyInfo.contactEmail}?subject=${emailSubject}&body=${emailBody}`;
                     Linking.openURL(mailtoLink);
@@ -706,7 +709,7 @@ export default class HomeScreen extends React.Component<
             color="orange"
             title="getStudyInfoAsync()"
             onPress={async () => {
-              alertWithShareButtonContainingDebugInfo(
+              await alertWithShareButtonContainingDebugInfoAsync(
                 JSON.stringify(await getStudyInfoAsync()),
               );
             }}
@@ -715,7 +718,7 @@ export default class HomeScreen extends React.Component<
             color="orange"
             title="getStudyStartDate()"
             onPress={async () => {
-              alertWithShareButtonContainingDebugInfo(
+              await alertWithShareButtonContainingDebugInfoAsync(
                 getStudyStartDate(await getStudyInfoAsync()).toString(),
               );
             }}
@@ -724,7 +727,7 @@ export default class HomeScreen extends React.Component<
             color="orange"
             title="getStudyEndDate()"
             onPress={async () => {
-              alertWithShareButtonContainingDebugInfo(
+              await alertWithShareButtonContainingDebugInfoAsync(
                 getStudyEndDate(await getStudyInfoAsync()).toString(),
               );
             }}
@@ -734,7 +737,7 @@ export default class HomeScreen extends React.Component<
             title="getIncomingNotificationTimeAsync()"
             onPress={async () => {
               const nextPingTime = await getIncomingNotificationTimeAsync();
-              alertWithShareButtonContainingDebugInfo(
+              await alertWithShareButtonContainingDebugInfoAsync(
                 nextPingTime
                   ? format(nextPingTime, "yyyy-MM-dd' T 'HH:mm:ss.SSSxxx")
                   : "IS NULL",
@@ -746,7 +749,7 @@ export default class HomeScreen extends React.Component<
             title="getLatestPingAsync()"
             onPress={async () => {
               const latestStartedPing = await getLatestPingAsync();
-              alertWithShareButtonContainingDebugInfo(
+              await alertWithShareButtonContainingDebugInfoAsync(
                 JSON.stringify(latestStartedPing),
               );
             }}
@@ -756,7 +759,7 @@ export default class HomeScreen extends React.Component<
             title="getCurrentNotificationTimeAsync()"
             onPress={async () => {
               const currentNotificationTime = await getCurrentNotificationTimeAsync();
-              alertWithShareButtonContainingDebugInfo(
+              await alertWithShareButtonContainingDebugInfoAsync(
                 JSON.stringify(currentNotificationTime),
               );
             }}
@@ -783,7 +786,7 @@ export default class HomeScreen extends React.Component<
               notificationsTimes!.forEach((element) => {
                 text += format(element, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx") + `\n`;
               });
-              alertWithShareButtonContainingDebugInfo(text);
+              await alertWithShareButtonContainingDebugInfoAsync(text);
             }}
           />
           <Button
@@ -791,7 +794,7 @@ export default class HomeScreen extends React.Component<
             title="getNumbersOfPingsForAllStreamNamesAsync()"
             onPress={async () => {
               const typesOfPingsAnswered = await getNumbersOfPingsForAllStreamNamesAsync();
-              alertWithShareButtonContainingDebugInfo(
+              await alertWithShareButtonContainingDebugInfoAsync(
                 JSON.stringify(typesOfPingsAnswered),
               );
             }}
@@ -801,7 +804,9 @@ export default class HomeScreen extends React.Component<
             title="secureGetUserAsync()"
             onPress={async () => {
               const user = await secureGetUserAsync();
-              alertWithShareButtonContainingDebugInfo(JSON.stringify(user));
+              await alertWithShareButtonContainingDebugInfoAsync(
+                JSON.stringify(user),
+              );
             }}
           />
           <Button
@@ -809,7 +814,7 @@ export default class HomeScreen extends React.Component<
             title="getFuturePingsQueue()"
             onPress={async () => {
               const futurePingsQueues = await getFuturePingsQueue();
-              alertWithShareButtonContainingDebugInfo(
+              await alertWithShareButtonContainingDebugInfoAsync(
                 JSON.stringify(futurePingsQueues),
               );
             }}
@@ -826,7 +831,9 @@ export default class HomeScreen extends React.Component<
             title="getAllDataAsync()"
             onPress={async () => {
               const allData = await getAllDataAsync();
-              alertWithShareButtonContainingDebugInfo(JSON.stringify(allData));
+              await alertWithShareButtonContainingDebugInfoAsync(
+                JSON.stringify(allData),
+              );
             }}
           />
           <Button
@@ -834,7 +841,7 @@ export default class HomeScreen extends React.Component<
             title="getUnuploadedDataAsync()"
             onPress={async () => {
               const unuploadedData = await getUnuploadedDataAsync();
-              alertWithShareButtonContainingDebugInfo(
+              await alertWithShareButtonContainingDebugInfoAsync(
                 JSON.stringify(unuploadedData),
               );
             }}
@@ -849,11 +856,11 @@ export default class HomeScreen extends React.Component<
                   this.setUploadStatusSymbol,
                   { unuploadedOnly: false },
                 );
-                alertWithShareButtonContainingDebugInfo(
+                await alertWithShareButtonContainingDebugInfoAsync(
                   JSON.stringify(response),
                 );
               } catch (e) {
-                alertWithShareButtonContainingDebugInfo(`${e}`);
+                await alertWithShareButtonContainingDebugInfoAsync(`${e}`);
               }
             }}
           />
@@ -867,11 +874,11 @@ export default class HomeScreen extends React.Component<
                   this.setUploadStatusSymbol,
                   { unuploadedOnly: true },
                 );
-                alertWithShareButtonContainingDebugInfo(
+                await alertWithShareButtonContainingDebugInfoAsync(
                   JSON.stringify(response),
                 );
               } catch (e) {
-                alertWithShareButtonContainingDebugInfo(`${e}`);
+                await alertWithShareButtonContainingDebugInfoAsync(`${e}`);
               }
             }}
           />
@@ -890,7 +897,7 @@ export default class HomeScreen extends React.Component<
                 (await getDashboardUrlAsync(studyInfo, firebaseUser)) ??
                 "No dashboard URL.";
               Clipboard.setString(url);
-              alertWithShareButtonContainingDebugInfo(url);
+              await alertWithShareButtonContainingDebugInfoAsync(url);
             }}
           />
           <Button

--- a/src/RootScreen.tsx
+++ b/src/RootScreen.tsx
@@ -10,7 +10,7 @@ import {
 } from "./helpers/asyncStorage/tempStudyFile";
 import {
   getCriticalProblemTextForUser,
-  alertWithShareButtonContainingDebugInfo,
+  alertWithShareButtonContainingDebugInfoAsync,
   getNonCriticalProblemTextForUser,
 } from "./helpers/debug";
 import { validateAndInitializeFirebaseWithConfig } from "./helpers/firebase";
@@ -150,7 +150,7 @@ export default class RootScreen extends React.Component<
         } catch (e) {
           await this.logoutFnAsync();
           this.setState({ isLoading: false });
-          alertWithShareButtonContainingDebugInfo(
+          await alertWithShareButtonContainingDebugInfoAsync(
             getCriticalProblemTextForUser(
               `componentDidMount validateAndInitializeFirebaseWithConfig: ${e}`,
             ),
@@ -171,7 +171,7 @@ export default class RootScreen extends React.Component<
         // still try to find study file when it is already deleted.
         await this.logoutFnAsync();
         this.setState({ isLoading: false });
-        alertWithShareButtonContainingDebugInfo(
+        await alertWithShareButtonContainingDebugInfoAsync(
           getNonCriticalProblemTextForUser(
             `You have been logged out for an unknown reason. ` +
               `Please uninstall the app, reinstall the app, and try logging in again. ` +

--- a/src/components/DashboardComponent.tsx
+++ b/src/components/DashboardComponent.tsx
@@ -6,7 +6,7 @@ import { WebView } from "react-native-webview";
 
 import { INSTALLATION_ID } from "../helpers/debug";
 import { base64ToBase64URL, getHashedPasswordAsync } from "../helpers/helpers";
-import { getLoginSessionID } from "../helpers/loginSession";
+import { getLoginSessionIDAsync } from "../helpers/loginSession";
 import {
   getPingsAsync,
   getThisWeekPingsAsync,
@@ -63,7 +63,7 @@ export async function getDashboardUrlAsync(
     let loginSessionId = "N/A";
     const user = await secureGetUserAsync();
     if (user) {
-      loginSessionId = getLoginSessionID(user);
+      loginSessionId = await getLoginSessionIDAsync(user);
     }
     dashboardUrl = dashboardUrl
       .split(LOGIN_SESSION_ID_PLACEHOLDER)

--- a/src/components/DashboardComponent.tsx
+++ b/src/components/DashboardComponent.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { Text, View } from "react-native";
 import { WebView } from "react-native-webview";
 
-import { INSTALLATION_ID } from "../helpers/debug";
+import { getInstallationIDAsync } from "../helpers/debug";
 import { base64ToBase64URL, getHashedPasswordAsync } from "../helpers/helpers";
 import { getLoginSessionIDAsync } from "../helpers/loginSession";
 import {
@@ -46,7 +46,7 @@ export async function getDashboardUrlAsync(
   if (dashboardUrl.includes(INSTALLATION_ID_PLACEHOLDER)) {
     dashboardUrl = dashboardUrl
       .split(INSTALLATION_ID_PLACEHOLDER)
-      .join(INSTALLATION_ID);
+      .join(await getInstallationIDAsync());
   }
 
   if (dashboardUrl.includes(STUDY_ID_PLACEHOLDER)) {

--- a/src/helpers/asyncStorage/asyncStorage.ts
+++ b/src/helpers/asyncStorage/asyncStorage.ts
@@ -1,6 +1,7 @@
 import { getStudyInfoAsync } from "../studyFile";
+import { ASYNC_STORAGE_WELLPING_PREFIX } from "./asyncStorageConfig";
 
 export async function getASKeyAsync(key: string = ""): Promise<string> {
   const studyInfo = await getStudyInfoAsync();
-  return `@WELLPING:Study_${studyInfo.id}/${key}`;
+  return `${ASYNC_STORAGE_WELLPING_PREFIX}Study_${studyInfo.id}/${key}`;
 }

--- a/src/helpers/asyncStorage/asyncStorageConfig.ts
+++ b/src/helpers/asyncStorage/asyncStorageConfig.ts
@@ -1,0 +1,1 @@
+export const ASYNC_STORAGE_WELLPING_PREFIX = "@WELLPING:";

--- a/src/helpers/beiwe.ts
+++ b/src/helpers/beiwe.ts
@@ -9,7 +9,7 @@ import { Platform } from "react-native";
 import { UploadData } from "./dataUpload";
 import { JS_VERSION_NUMBER } from "./debug";
 import { base64ToBase64URL, getHashedPasswordAsync } from "./helpers";
-import { getLoginSessionID } from "./loginSession";
+import { getLoginSessionIDAsync } from "./loginSession";
 import { User, secureGetUserAsync } from "./secureStore/user";
 import { DataUploadServerResponse, getBeiweServerConfig } from "./server";
 import { getStudyInfoAsync } from "./studyFile";
@@ -93,7 +93,7 @@ async function getRequestURLAsync(
 
   const passwordHash = await getHashedPasswordAsync(user.password);
   request["password"] = base64ToBase64URL(passwordHash);
-  request["device_id"] = getLoginSessionID(user);
+  request["device_id"] = await getLoginSessionIDAsync(user);
   request["username"] = user.username;
   request["patient_id"] = user.username;
 

--- a/src/helpers/dataUpload.ts
+++ b/src/helpers/dataUpload.ts
@@ -8,7 +8,7 @@ import {
   USER_INSTALLATION_INFO,
 } from "./debug";
 import { firebaseUploadDataForUserAsync } from "./firebase";
-import { getLoginSessionID } from "./loginSession";
+import { getLoginSessionIDAsync } from "./loginSession";
 import { getPingsAsync } from "./pings";
 import { secureGetUserAsync } from "./secureStore/user";
 import {
@@ -44,7 +44,7 @@ async function _getUserDataAsync(): Promise<UserData> {
   }
   return {
     username: user.username,
-    loginSessionId: getLoginSessionID(user),
+    loginSessionId: await getLoginSessionIDAsync(user),
     installation: USER_INSTALLATION_INFO,
   };
 }

--- a/src/helpers/dataUpload.ts
+++ b/src/helpers/dataUpload.ts
@@ -5,7 +5,7 @@ import { beiweUploadDataForUserAsync } from "./beiwe";
 import {
   UserInstallationInfo,
   HOME_SCREEN_DEBUG_VIEW_SYMBOLS,
-  USER_INSTALLATION_INFO,
+  getUserInstallationInfoAsync,
 } from "./debug";
 import { firebaseUploadDataForUserAsync } from "./firebase";
 import { getLoginSessionIDAsync } from "./loginSession";
@@ -45,7 +45,7 @@ async function _getUserDataAsync(): Promise<UserData> {
   return {
     username: user.username,
     loginSessionId: await getLoginSessionIDAsync(user),
-    installation: USER_INSTALLATION_INFO,
+    installation: await getUserInstallationInfoAsync(),
   };
 }
 

--- a/src/helpers/debug.ts
+++ b/src/helpers/debug.ts
@@ -92,7 +92,7 @@ export function getCriticalProblemTextForUser(problem: string) {
   return `[CRITICAL ERROR (Please screenshot this page and send it to the study staff as soon as possible): ${problem}]`;
 }
 
-export function alertWithShareButtonContainingDebugInfo(
+export async function alertWithShareButtonContainingDebugInfoAsync(
   text: string,
   title: string = "Alert",
   moreButtons: AlertButton[] = [],
@@ -101,8 +101,8 @@ export function alertWithShareButtonContainingDebugInfo(
     ...moreButtons,
     {
       text: "Share Data with Research Staff",
-      onPress: () => {
-        shareDebugText(text);
+      onPress: async () => {
+        await shareDebugTextAsync(text);
       },
     },
     {
@@ -112,14 +112,14 @@ export function alertWithShareButtonContainingDebugInfo(
   ]);
 }
 
-export function getUsefulDebugInfo(): string {
+export async function getUsefulDebugInfoAsync(): Promise<string> {
   return JSON.stringify(USER_INSTALLATION_INFO);
 }
 
-export function shareDebugText(debugText: string) {
+export async function shareDebugTextAsync(debugText: string) {
   Share.share({
     message:
       `Please enter any additional information here:\n\n\n\n` +
-      `====\n${debugText}\n\n====\n${getUsefulDebugInfo()}`,
+      `====\n${debugText}\n\n====\n${await getUsefulDebugInfoAsync()}`,
   });
 }

--- a/src/helpers/debug.ts
+++ b/src/helpers/debug.ts
@@ -1,6 +1,10 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import Constants from "expo-constants";
 import * as Device from "expo-device";
 import { Share, Alert, AlertButton } from "react-native";
+import uuid from "react-native-uuid";
+
+import { ASYNC_STORAGE_WELLPING_PREFIX } from "./asyncStorage/asyncStorageConfig";
 
 // Notice that this version number is different from the app version number
 // which is the number submitted App Store and Google Store.
@@ -12,11 +16,30 @@ export const JS_VERSION_NUMBER = "js.2.10.27.1";
 export const NATIVE_VERSION_NUMBER = Constants.nativeAppVersion;
 export const NATIVE_BUILD_NUMBER = Constants.nativeBuildVersion;
 export const EXPO_VERSION = Constants.expoVersion;
-export const INSTALLATION_ID = Constants.installationId;
+
+/**
+ * A random ID for the device.
+ */
+export const getInstallationIDAsync: () => Promise<string> = async () => {
+  let result = "ASYNCGETINSTALLATIONIDERROR";
+  try {
+    const key = `${ASYNC_STORAGE_WELLPING_PREFIX}InstallationID`;
+    const value = await AsyncStorage.getItem(key);
+    if (value === null) {
+      result = `${uuid.v4()}`;
+      await AsyncStorage.setItem(key, result);
+    } else {
+      result = value;
+    }
+  } catch (e) {
+    // error
+  }
+  return result;
+};
 
 export type UserInstallationInfo = {
   app: {
-    installationId: typeof INSTALLATION_ID;
+    installationId: string;
     jsVersion: typeof JS_VERSION_NUMBER;
     nativeVersion: typeof NATIVE_VERSION_NUMBER;
     nativeBuild: typeof NATIVE_BUILD_NUMBER;
@@ -33,24 +56,28 @@ export type UserInstallationInfo = {
     osVersion: typeof Device.osVersion;
   };
 };
-export const USER_INSTALLATION_INFO: UserInstallationInfo = {
-  app: {
-    installationId: INSTALLATION_ID,
-    jsVersion: JS_VERSION_NUMBER,
-    nativeVersion: NATIVE_VERSION_NUMBER,
-    nativeBuild: NATIVE_BUILD_NUMBER,
-    expoVersion: EXPO_VERSION,
-  },
-  device: {
-    brand: Device.brand,
-    manufacturer: Device.manufacturer,
-    modelName: Device.modelName,
-    modelId: Device.modelId,
-    designName: Device.designName,
-    productName: Device.productName,
-    osName: Device.osName,
-    osVersion: Device.osVersion,
-  },
+export const getUserInstallationInfoAsync: () => Promise<
+  UserInstallationInfo
+> = async () => {
+  return {
+    app: {
+      installationId: await getInstallationIDAsync(),
+      jsVersion: JS_VERSION_NUMBER,
+      nativeVersion: NATIVE_VERSION_NUMBER,
+      nativeBuild: NATIVE_BUILD_NUMBER,
+      expoVersion: EXPO_VERSION,
+    },
+    device: {
+      brand: Device.brand,
+      manufacturer: Device.manufacturer,
+      modelName: Device.modelName,
+      modelId: Device.modelId,
+      designName: Device.designName,
+      productName: Device.productName,
+      osName: Device.osName,
+      osVersion: Device.osVersion,
+    },
+  };
 };
 
 export const HOME_SCREEN_DEBUG_VIEW_SYMBOLS = {
@@ -113,7 +140,7 @@ export async function alertWithShareButtonContainingDebugInfoAsync(
 }
 
 export async function getUsefulDebugInfoAsync(): Promise<string> {
-  return JSON.stringify(USER_INSTALLATION_INFO);
+  return JSON.stringify(await getUserInstallationInfoAsync());
 }
 
 export async function shareDebugTextAsync(debugText: string) {

--- a/src/helpers/firebase.ts
+++ b/src/helpers/firebase.ts
@@ -6,7 +6,7 @@
 import firebase from "firebase/app";
 
 import { UploadData } from "./dataUpload";
-import { getLoginSessionID } from "./loginSession";
+import { getLoginSessionIDAsync } from "./loginSession";
 import { User } from "./secureStore/user";
 import { DataUploadServerResponse, getFirebaseServerConfig } from "./server";
 import { StudyInfo } from "./types";
@@ -108,8 +108,8 @@ export async function firebaseUploadDataForUserAsync(
     const dataPlain = JSON.parse(JSON.stringify(data));
     await firebase
       .database()
-      // TODO: verify getLoginSessionID is working correctly here
-      .ref(`users/${user.uid}/${getLoginSessionID(localUser)}`)
+      // TODO: verify getLoginSessionIDAsync is working correctly here
+      .ref(`users/${user.uid}/${await getLoginSessionIDAsync(localUser)}`)
       .set(dataPlain);
     endUploading();
     // TODO: support new_pings_count` and `new_answers_count.

--- a/src/helpers/loginSession.ts
+++ b/src/helpers/loginSession.ts
@@ -1,6 +1,6 @@
-import { INSTALLATION_ID } from "./debug";
+import { getInstallationIDAsync } from "./debug";
 import { User } from "./secureStore/user";
 
 export const getLoginSessionIDAsync = async (user: User): Promise<string> => {
-  return `${user.username}-${INSTALLATION_ID}-${user.loginDate}`;
+  return `${user.username}-${await getInstallationIDAsync()}-${user.loginDate}`;
 };

--- a/src/helpers/loginSession.ts
+++ b/src/helpers/loginSession.ts
@@ -1,6 +1,6 @@
 import { INSTALLATION_ID } from "./debug";
 import { User } from "./secureStore/user";
 
-export const getLoginSessionID = (user: User): string => {
+export const getLoginSessionIDAsync = async (user: User): Promise<string> => {
   return `${user.username}-${INSTALLATION_ID}-${user.loginDate}`;
 };

--- a/src/helpers/secureStore/secureStore.ts
+++ b/src/helpers/secureStore/secureStore.ts
@@ -1,14 +1,14 @@
-import { INSTALLATION_ID } from "../debug";
+import { getInstallationIDAsync } from "../debug";
 import { getStudyInfoAsync } from "../studyFile";
 
 export async function getSSKeyAsync(key: string = ""): Promise<string> {
   const studyInfo = await getStudyInfoAsync();
   // Keys provided to SecureStore must not be empty and contain only
   // alphanumeric characters, ".", "-", and "_".
-  // Note: We include `INSTALLATION_ID` so that the data will NOT be accessible
+  // Note: We include an "installation ID" so that the data will NOT be accessible
   // across different installations (as SecureStore will be accessible across
   // different installations by default on iOS).
-  // TODO: `INSTALLATION_ID` will be deprecated. So need to find a better way
-  // of doing this (probably use app first launch date?).
-  return `WELLPING-${INSTALLATION_ID}-Study_${studyInfo.id}.${key}`;
+  return `WELLPING-${await getInstallationIDAsync()}-Study_${
+    studyInfo.id
+  }.${key}`;
 }

--- a/src/questionScreens/SliderQuestionScreen.tsx
+++ b/src/questionScreens/SliderQuestionScreen.tsx
@@ -9,7 +9,7 @@ import {
 } from "../helpers/answerTypes";
 import {
   getNonCriticalProblemTextForUser,
-  alertWithShareButtonContainingDebugInfo,
+  alertWithShareButtonContainingDebugInfoAsync,
 } from "../helpers/debug";
 import { SliderQuestion } from "../helpers/types";
 import { SLIDER_DEFAULTS } from "./constants";
@@ -51,7 +51,7 @@ const SliderQuestionScreen: React.ElementType<SliderQuestionScreenProps> = ({
         question.defaultValueFromQuestionId
       ] as SliderQuestion;
       if (prevQuestion == null) {
-        alertWithShareButtonContainingDebugInfo(
+        alertWithShareButtonContainingDebugInfoAsync(
           getNonCriticalProblemTextForUser(
             `defaultValueFromQuestionId ${question.defaultValueFromQuestionId} prevQuestion == null`,
           ),

--- a/src/screens/LoadingScreen.tsx
+++ b/src/screens/LoadingScreen.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View, Text, Button } from "react-native";
 
-import { JS_VERSION_NUMBER, shareDebugText } from "../helpers/debug";
+import { JS_VERSION_NUMBER, shareDebugTextAsync } from "../helpers/debug";
 import { styles } from "../helpers/styles";
 
 const TEXT_COLOR = "#ededed";
@@ -25,8 +25,8 @@ const LoadingScreen: React.FunctionComponent = () => {
       <Button
         title="Share Error"
         color={TEXT_COLOR}
-        onPress={() => {
-          shareDebugText("Stuck on the loading page.");
+        onPress={async () => {
+          await shareDebugTextAsync("Stuck on the loading page.");
         }}
       />
       <Text

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -15,9 +15,9 @@ import {
 import { CONFIG } from "../../config/config";
 import {
   JS_VERSION_NUMBER,
-  alertWithShareButtonContainingDebugInfo,
+  alertWithShareButtonContainingDebugInfoAsync,
   getCriticalProblemTextForUser,
-  shareDebugText,
+  shareDebugTextAsync,
 } from "../helpers/debug";
 import { LoginSchema } from "../helpers/schemas/Login";
 import { User } from "../helpers/secureStore/user";
@@ -343,8 +343,8 @@ export default class LoginScreen extends React.Component<
             </Text>
             <Text style={{ marginTop: 20 }}>{errorText}</Text>
             <Button
-              onPress={() => {
-                shareDebugText(errorText);
+              onPress={async () => {
+                await shareDebugTextAsync(errorText);
               }}
               title="Share Error"
             />
@@ -366,7 +366,7 @@ export default class LoginScreen extends React.Component<
         <TouchableWithoutFeedback
           onLongPress={async () => {
             //this.setState({ displayDebugView: true });
-            alertWithShareButtonContainingDebugInfo(
+            await alertWithShareButtonContainingDebugInfoAsync(
               `parseInitialURLAsync:\n${JSON.stringify(
                 await Linking.parseInitialURLAsync(),
               )}`,

--- a/src/screens/StudyFileErrorScreen.tsx
+++ b/src/screens/StudyFileErrorScreen.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, TextInput, Text, View } from "react-native";
 
-import { shareDebugText } from "../helpers/debug";
+import { shareDebugTextAsync } from "../helpers/debug";
 
 interface StudyFileErrorScreenProps {
   errorText: string;
@@ -47,8 +47,8 @@ export default class StudyFileErrorScreen extends React.Component<
               (Restart the app to try again.)
             </Text>
             <Button
-              onPress={() => {
-                shareDebugText(errorText);
+              onPress={async () => {
+                shareDebugTextAsync(errorText);
               }}
               title="Send the error message to the research staff"
             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -8559,6 +8559,11 @@ react-native-testing-library@^2.1.0:
   dependencies:
     pretty-format "^26.0.1"
 
+react-native-uuid@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-uuid/-/react-native-uuid-2.0.1.tgz#ed4e2dfb1683eddb66967eb5dca140dfe1abddb9"
+  integrity sha512-cptnoIbL53GTCrWlb/+jrDC6tvb7ypIyzbXNJcpR3Vab0mkeaaVd5qnB3f0whXYzS+SMoSQLcUUB0gEWqkPC0g==
+
 react-native-webview@11.13.0:
   version "11.13.0"
   resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.13.0.tgz#a2eca0f87b2ae9bba0dd8144594aeff9947cc5d6"


### PR DESCRIPTION
`Constants.installationId` is deprecated and will be removed in SDK 44. We replace that with a random UUID generated at the app's first launch and stored in AsyncStorage.